### PR TITLE
Fixed passport can't validate state value.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 var util = require('util'),
+	_ = require('underscore'),
 	xml2js = require('xml2js'),
 	parseString = xml2js.parseString,
 	Profile = require('./profile'),
@@ -36,17 +37,18 @@ util.inherits(Strategy, OAuth2Strategy);
 /**
  * Return extra parameters to be included in the authorization request.
  */
-Strategy.prototype.authorizationParams = function (params) {
-	var options = this.__options;
-
-	params = params || {};
+Strategy.prototype.authorizationParams = function (options) {
+	// Do not modify `options` object.
+	// It will hurts original options object which in `passport.authenticate(..., options)`
+	var params = _.extend({}, options);
 	params['response_type'] = 'code';
+
 
 	// @see https://github.com/naver/passport-naver/commit/2d88b7aeb14ce04db81a145b2933baabba80612b
 	// @see http://gamedev.naver.com/index.php/%EC%98%A8%EB%9D%BC%EC%9D%B8%EA%B2%8C%EC%9E%84:OAuth_2.0_API
-	if (options.svcType !== undefined) params['svctype'] = options.svcType;
+	if (this.__options.svcType !== undefined) params['svctype'] = this.__options.svcType;
 	// @see https://github.com/naver/passport-naver#re-authentication
-	if (options.authType !== undefined) params['auth_type'] = options.authType;
+	if (this.__options.authType !== undefined) params['auth_type'] = this.__options.authType;
 
 	return params;
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "main": "./lib",
   "dependencies": {
     "passport-oauth": "^1.0.0",
+    "underscore": "^1.8.3",
     "xml2js": "^0.4.4"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
- `authorizationParams` method will perform deep-copy instead of shallow-copy because it hurts original `options` object.
